### PR TITLE
Classic UI Fix

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2269,10 +2269,8 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			}
 		}
 
-		$this->inventory->equipItem($packet->hotbarSlot, $packet->inventorySlot);
-
+		$this->inventory->setHeldItemIndex($packet->hotbarSlot, false, $packet->inventorySlot);
 		$this->setDataFlag(self::DATA_FLAGS, self::DATA_FLAG_ACTION, false);
-
 		return true;
 	}
 


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
When Classic UI , moving something from held item slot to somewhere in the inventory glitches the item. This fixes it.
### Relevant issues
<!-- List relevant issues here -->
<!--

None

-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
None what so ever

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? --> Not tested for backwards incompatible changes/

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Test before and after with code I guess?
<!--

Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
Just move something from the hotbar slot to somewhere in the inventory and it will glitch. Use the updated code and it wont.

