### PR TITLE
Ignore Slots That Have Air

### DIFF
--- a/src/pocketmine/Player.php
+++ b/src/pocketmine/Player.php
@@ -2283,6 +2283,13 @@ class Player extends Human implements CommandSender, InventoryHolder, ChunkLoade
 			$item = $this->inventory->getItem($packet->inventorySlot);
 
 			if(!$item->equals($packet->item)){
+				if($item->getId() === 0) {
+					return false;
+				}
+
+				if($packet->item->getId() === 0) {
+					return false;
+				}
 				$this->server->getLogger()->debug("Tried to equip " . $packet->item . " but have " . $item . " in target slot");
 				$this->inventory->sendContents($this);
 				return false;


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
This fixes drag and dropping items to the hotbar on windows 10. 

### Relevant issues
<!-- List relevant issues here -->
<!--



-->

## Changes
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
None
### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
none sited
## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Not sure
## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
<!--
Test just a bit more
Requires translations:

| Name | Value in eng.ini |
| :--: | :---: |
| `foo.bar` | `Foo bar` |

-->

## Tests
<!-- Attach scripts or actions to test this pull request, as well as the result -->
